### PR TITLE
Fixed News header not being active

### DIFF
--- a/news.html
+++ b/news.html
@@ -30,7 +30,7 @@
 			</button>
 			<div class="collapse navbar-collapse" id="navbarNavDropdown">
 				<ul class="navbar-nav mr-auto">
-					<li class="nav-item">
+					<li class="nav-item active">
 						<a class="nav-link" href="news.html">News</a>
 					</li>
 					<li class="nav-item dropdown">


### PR DESCRIPTION
News now shows as active in header bar while on page: Fixed #49 