### PR TITLE
Added Name to CSGO results iframe

### DIFF
--- a/teams/csgo.html
+++ b/teams/csgo.html
@@ -66,7 +66,7 @@
 
 	<main>
 		<div class=h_iframe>
-			<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTUxfCIEtEExMuKeLJFUuAnhA_fkTDu6TglwZpRTp-ZjSZQKwCfJ8ky3rIwDNVha7d5eigKc-QYoH3c/pubhtml?gid=483156693&amp;single=true&amp;widget=true&amp;headers=false" frameborder="0" allowfullscreen></iframe>
+			<iframe src="https://docs.google.com/spreadsheets/d/e/2PACX-1vTUxfCIEtEExMuKeLJFUuAnhA_fkTDu6TglwZpRTp-ZjSZQKwCfJ8ky3rIwDNVha7d5eigKc-QYoH3c/pubhtml?gid=483156693&amp;single=true&amp;widget=true&amp;headers=false" frameborder="0" allowfullscreen> CSGO Results Table</iframe>
 		</div>
 	</main>
 


### PR DESCRIPTION
Added the name CSGO results table to the iframe since not having one is an accessibility failure per lighthouse.